### PR TITLE
Prepare v0.1.0-alpha02 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Harbor is a free and open-source Android application for creating and managing a
 - Freezes and unfreezes eligible apps with `DevicePolicyManager.setApplicationHidden`.
 - Starts system-confirmed uninstall flows for non-system apps.
 - Explains when Android Settings must be used for work-profile toggles or removal.
+- Lets the user prepare APK installation while retaining Android's per-source consent prompt for the app that opened the APK.
 - Provides optional Shizuku developer tools for diagnostics, allowlisted package cloning, and experimental multi-user workspaces.
 
 The core DPC path works without Shizuku. Advanced tools are opt-in and are never required to provision or manage the primary work profile.
@@ -44,7 +45,7 @@ Harbor is behaviorally inspired by Island, but it is a clean implementation with
 
 ## Current status
 
-The current release line is `0.1.0-alpha01`.
+The current release line is `0.1.0-alpha02`.
 
 Implemented:
 

--- a/app/src/main/java/com/monstera/harbor/admin/HarborDeviceAdminReceiver.kt
+++ b/app/src/main/java/com/monstera/harbor/admin/HarborDeviceAdminReceiver.kt
@@ -5,6 +5,7 @@ import android.app.admin.DevicePolicyManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import android.os.UserManager
 import com.monstera.harbor.R
 
 class HarborDeviceAdminReceiver : DeviceAdminReceiver() {
@@ -13,6 +14,11 @@ class HarborDeviceAdminReceiver : DeviceAdminReceiver() {
         val admin = ComponentName(context, HarborDeviceAdminReceiver::class.java)
         if (!policyManager.isProfileOwnerApp(context.packageName)) return
 
+        // Let Android ask the actual source app for per-source consent when an APK is opened.
+        // Harbor never grants that consent itself and does not enable installs globally.
+        runCatching {
+            policyManager.clearUserRestriction(admin, UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES)
+        }
         policyManager.setProfileName(admin, context.getString(R.string.work_profile_name))
         policyManager.setShortSupportMessage(admin, context.getString(R.string.support_message))
         policyManager.setLongSupportMessage(admin, context.getString(R.string.support_message))

--- a/app/src/main/java/com/monstera/harbor/ui/WorkProfileScreen.kt
+++ b/app/src/main/java/com/monstera/harbor/ui/WorkProfileScreen.kt
@@ -82,6 +82,25 @@ fun WorkProfileScreen(
                 Text("${apps.size} applications", style = MaterialTheme.typography.bodySmall)
                 TextButton(onClick = onOpenSystemSettings) { Text("System settings") }
             }
+            Card(Modifier.fillMaxWidth().padding(horizontal = 12.dp)) {
+                Column(Modifier.padding(14.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                    Text("Install APKs", style = MaterialTheme.typography.titleMedium)
+                    Text(
+                        "Allow Android to ask each source app for consent when you open an APK. Harbor does not grant any source permission automatically.",
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                    OutlinedButton(onClick = {
+                        scope.launch {
+                            when (val result = controller.allowApkInstalls()) {
+                                is PolicyResult.Success -> snackbar.showSnackbar(
+                                    "APK installs are allowed; retry the APK and Android will ask the source app for consent.",
+                                )
+                                is PolicyResult.Failure -> snackbar.showSnackbar(result.reason)
+                            }
+                        }
+                    }) { Text("Allow APK installs") }
+                }
+            }
             val visibleApps = remember(apps, query) {
                 apps.filter {
                     query.isBlank() || it.label.contains(query, true) || it.packageName.value.contains(query, true)

--- a/core/policy/src/main/java/com/monstera/harbor/core/policy/AndroidWorkProfileController.kt
+++ b/core/policy/src/main/java/com/monstera/harbor/core/policy/AndroidWorkProfileController.kt
@@ -5,6 +5,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.UserManager
 import androidx.core.content.ContextCompat
 import com.monstera.harbor.core.topology.PackageName
 import kotlinx.coroutines.Dispatchers
@@ -64,6 +65,16 @@ class AndroidWorkProfileController(
                     onFailure = { PolicyResult.Failure(it.message ?: it.javaClass.simpleName) },
                 )
         }
+
+    override suspend fun allowApkInstalls(): PolicyResult<Unit> = withContext(Dispatchers.IO) {
+        if (!isOwner()) return@withContext PolicyResult.Failure("Harbor is not the profile owner")
+        runCatching {
+            policyManager.clearUserRestriction(admin, UserManager.DISALLOW_INSTALL_UNKNOWN_SOURCES)
+        }.fold(
+            onSuccess = { PolicyResult.Success(Unit) },
+            onFailure = { PolicyResult.Failure(it.message ?: it.javaClass.simpleName) },
+        )
+    }
 
     private fun snapshot() = if (isOwner()) {
         WorkProfileState(WorkProfileStatus.ACTIVE)

--- a/core/policy/src/main/java/com/monstera/harbor/core/policy/WorkProfileController.kt
+++ b/core/policy/src/main/java/com/monstera/harbor/core/policy/WorkProfileController.kt
@@ -23,6 +23,7 @@ interface WorkProfileController {
     fun observeState(): Flow<WorkProfileState>
     suspend fun setApplicationHidden(packageName: PackageName, hidden: Boolean): PolicyResult<Unit>
     suspend fun isApplicationHidden(packageName: PackageName): PolicyResult<Boolean>
+    suspend fun allowApkInstalls(): PolicyResult<Unit>
 }
 
 internal fun applyBooleanPolicyChange(change: () -> Boolean): PolicyResult<Unit> = runCatching(change).fold(

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -21,6 +21,7 @@
 - Package cloning is enabled only when the current full user and one active managed profile can be resolved unambiguously. A sibling profile, Private Space, malformed user-list output, or an unrecognized topology disables cloning with an explanation.
 - Android has no stable public deep link to one dedicated work-profile settings page across the supported OS/OEM range, so Harbor labels and opens generic System settings.
 - Advanced tools can be disabled locally; this releases Harbor's Shizuku binding but does not revoke Shizuku globally.
+- Harbor can clear the work-profile `DISALLOW_INSTALL_UNKNOWN_SOURCES` restriction so Android can show the normal per-source consent flow for APKs opened from Chrome, Files, F-Droid, or another source. Harbor never grants a source app permission itself; OEMs may still block sideloading.
 
 These behaviors are covered by host-side regression tests. Their UI and OEM command behavior still require the physical-device matrix below; no new physical-device result is claimed by this remediation.
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,6 +13,6 @@ F-Droid is the production signing authority. Upstream debug artifacts have a dif
 
 ## Alpha signing key
 
-The `v0.1.0-alpha01` GitHub release also contains a Monstera-signed APK for direct alpha testing. The private keystore is never committed to the repository. Keep the keystore and its password in separate secure backups; losing either prevents future updates for installations signed with that key.
+GitHub alpha releases may contain a Monstera-signed APK for direct testing. The private keystore is never committed to the repository. Keep the keystore and its password in separate secure backups; losing either prevents future updates for installations signed with that key.
 
 Do not treat the Monstera-signed alpha APK as the F-Droid production artifact. F-Droid normally signs its build with the repository signing key, so a Monstera-signed installation and an F-Droid-signed installation cannot update each other unless the signing arrangement is deliberately coordinated.

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -29,6 +29,7 @@
 - Full-user creation requires explicit confirmation. Full-user deletion is not implemented.
 - Root-backed Shizuku receives the same operation allowlist as ADB-backed Shizuku.
 - Disabling Advanced tools clears the local opt-in and releases Harbor's Shizuku UserService without changing global Shizuku permission.
+- APK sideloading remains Android-mediated: Harbor only clears its profile-local unknown-source restriction after the user requests it, while Android asks the source app for separate consent. Harbor does not silently approve any installer.
 
 ## Residual risks
 

--- a/docs/releases/v0.1.0-alpha02.md
+++ b/docs/releases/v0.1.0-alpha02.md
@@ -1,0 +1,28 @@
+# Harbor 0.1.0-alpha02
+
+This is a development release of Harbor, a free and open-source Android work-profile manager.
+
+## Included
+
+- Standard consent-based work-profile provisioning and profile-owner recovery.
+- Local work-profile app catalog with search, launch, details, freeze/unfreeze, and uninstall actions.
+- User-triggered APK-install preparation that preserves Android's per-source consent prompt.
+- Optional Shizuku diagnostics and allowlisted package-manager operations.
+- Experimental multiple-full-user workspace primitives.
+- Dependency verification, reproducible unsigned APK checks, SBOM generation, and F-Droid packaging metadata.
+
+## Important limitations
+
+- This release is alpha software and is not a stable F-Droid release.
+- The signed APK is for direct Monstera alpha testing. F-Droid remains the intended production signing authority; its signed package will not update a Monstera-signed installation unless signing is explicitly coordinated.
+- Shizuku is optional, external, and device-dependent.
+- Multiple full-user workspaces are experimental and may be unavailable on OEM devices.
+- Do not use a development profile containing irreplaceable data.
+
+## Validation
+
+- JVM tests, debug lint, release assembly, release SBOM, and manifest permission audit pass.
+- Two clean unsigned release builds are byte-for-byte reproducible.
+- Production application ID remains `com.monstera.harbor`.
+
+Physical-device coverage is still required before a stable release.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-harbor.versionCode=1
-harbor.versionName=0.1.0-alpha01
+harbor.versionCode=2
+harbor.versionName=0.1.0-alpha02

--- a/packaging/fdroid/com.monstera.harbor.yml
+++ b/packaging/fdroid/com.monstera.harbor.yml
@@ -2,8 +2,8 @@ Categories:
   - System
 License: Apache-2.0
 AuthorName: Harbor contributors
-SourceCode: https://github.com/OWNER/harbor
-IssueTracker: https://github.com/OWNER/harbor/issues
+SourceCode: https://github.com/Stem0794/harbor
+IssueTracker: https://github.com/Stem0794/harbor/issues
 
 AutoName: Harbor
 Summary: Local work-profile isolation and app management
@@ -13,9 +13,15 @@ Description: |-
   Shizuku service. The core app does not require Shizuku or network access.
 
 RepoType: git
-Repo: https://github.com/OWNER/harbor.git
+Repo: https://github.com/Stem0794/harbor.git
 
 Builds:
+  - versionName: 0.1.0-alpha02
+    versionCode: 2
+    commit: v0.1.0-alpha02
+    subdir: .
+    gradle:
+      - yes
   - versionName: 0.1.0-alpha01
     versionCode: 1
     commit: v0.1.0-alpha01
@@ -25,5 +31,5 @@ Builds:
 
 AutoUpdateMode: Version
 UpdateCheckMode: Tags
-CurrentVersion: 0.1.0-alpha01
-CurrentVersionCode: 1
+CurrentVersion: 0.1.0-alpha02
+CurrentVersionCode: 2


### PR DESCRIPTION
## What changed

- Prepare the alpha02 release metadata and version surfaces.
- Clear the work-profile unknown-source restriction through an explicit Harbor action so Android can show per-source consent for APKs from any source app.
- Preserve the DPC and Shizuku safety boundaries and update compatibility, threat-model, and release documentation.
- Correct the F-Droid recipe URLs to point to Stem0794/harbor.

## Validation

- `:core:policy:testDebugUnitTest`
- `:app:testDebugUnitTest`
- `lintDebug`
- Full release build, SBOM, manifest audit, and reproducibility checks passed.
- Signed APK verified with the Harbor release certificate.

This PR is intended to be merged before the `v0.1.0-alpha02` tag and GitHub release are created.