### PR TITLE
Release Harbor 0.2.0-alpha06

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ See [Compatibility](docs/COMPATIBILITY.md) for emulator results and device-speci
 
 ## Current release
 
-Current release line: **0.2.0-alpha05**
+Current release line: **0.2.0-alpha06**
 
 The core path includes managed-profile provisioning, local profile-owner detection, the searchable Work app catalog, app launch/details/uninstall, freeze/unfreeze, batch operations, Work-app shortcuts, Personal-to-Work file sharing, and local lifecycle/recovery handling.
 

--- a/fastlane/metadata/android/en-US/changelogs/8.txt
+++ b/fastlane/metadata/android/en-US/changelogs/8.txt
@@ -1,0 +1,1 @@
+Redesigns the Personal and Work interfaces with Harbor's privacy dashboard, persistent profile headers, improved large-font layouts, clearer settings and search, updated lighthouse branding, and more robust Work app shortcuts.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,5 +7,5 @@ android.nonTransitiveRClass=true
 android.nonFinalResIds=true
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
-harbor.versionCode=7
-harbor.versionName=0.2.0-alpha05
+harbor.versionCode=8
+harbor.versionName=0.2.0-alpha06


### PR DESCRIPTION
Prepares Harbor 0.2.0-alpha06 / versionCode 8 for the next F-Droid auto-update. Bumps the version, updates the README release line, and adds Fastlane changelog 8.txt. Existing physically validated Samsung Fastlane screenshots remain unchanged. Merge only after Android CI and reproducibility pass.