### PR TITLE
Refresh docs for alpha06 cross-profile support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Harbor is designed to keep its normal Work-profile path local and based on Andro
 - Create launcher shortcuts for Work apps.
 - Send selected files from Personal to Work.
 - Prepare APK installation while Android keeps its normal source-consent prompts.
+- On Android 11+, manage each Work app's eligibility for Android's cross-profile connection flow while leaving final consent to Android.
 
 Shizuku is **not required** for these normal Work-profile features.
 
@@ -135,6 +136,7 @@ Harbor is still alpha software, and some behavior remains device-dependent.
 - Some launcher behavior remains device-dependent.
 - Harbor supports Personal-to-Work file transfer, not Work-to-Personal export.
 - Android generally permits one managed profile per parent user.
+- Per-app cross-profile access requires Android 11 or newer and only controls app eligibility; Android still owns the final connection-consent flow.
 
 See [Compatibility](docs/COMPATIBILITY.md) for tested configurations and device-specific limitations.
 
@@ -168,7 +170,7 @@ For the detailed test matrix, see [Compatibility](docs/COMPATIBILITY.md).
 
 The OnePlus 13 remains planned secondary coverage and has not been tested yet.
 
-See [Compatibility](docs/COMPATIBILITY.md) for emulator results and device-specific limitations.
+See [Compatibility](docs/COMPATIBILITY.md) for emulator results, feature-specific user reports, and device-specific limitations.
 
 ## Privacy and security
 
@@ -207,6 +209,10 @@ The core app does not declare the `INTERNET` permission.
 ### Can Harbor send files from Work back to Personal?
 
 No. Harbor currently provides Personal-to-Work file transfer only.
+
+### How do I let an app such as microG connect across Personal and Work?
+
+On Android 11+, open Harbor inside the Work profile, open the app's action sheet, and enable its cross-profile access control. Harbor adds that package to Android's profile-owner eligibility allowlist without removing unrelated entries. Return to the app and complete Android's own connection-consent flow. Android 10 does not provide this public DPC API.
 
 ### Can I switch directly between a GitHub APK and the F-Droid build?
 

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -20,6 +20,12 @@
 
 Planned but not yet tested: OnePlus 13.
 
+## Feature-specific user confirmations
+
+These reports confirm a specific workflow only; they are not full-device compatibility passes.
+
+- Xiaomi Lisa running LineageOS 23.2: a user confirmed that microG Services can complete Android's Personal/Work connection flow with Harbor `0.2.0-alpha06` after enabling microG's per-app cross-profile access in Work Harbor. This validates the end-to-end microG use case for that reported setup, including Android's final consent step.
+
 ## Conservative compatibility behavior
 
 - Freeze/unfreeze treats a `false` result from Android as a failed policy update and leaves the displayed state unchanged.

--- a/site/index.html
+++ b/site/index.html
@@ -74,7 +74,7 @@
           <article>
             <span class="feature-number">02</span>
             <h3>Manage Work apps</h3>
-            <p>Launch, freeze, unfreeze, inspect, uninstall, and create shortcuts for apps inside Work.</p>
+            <p>Launch, freeze, unfreeze, inspect, uninstall, create shortcuts, and manage per-app cross-profile eligibility on Android 11+.</p>
           </article>
           <article>
             <span class="feature-number">03</span>


### PR DESCRIPTION
## Summary

- document Android 11+ per-app cross-profile eligibility controls in the README and website
- add a README FAQ for apps such as microG that need Android's cross-profile connection flow
- record the confirmed microG flow on Xiaomi Lisa / LineageOS 23.2 as feature-specific evidence, not a full compatibility pass

## Verification

- current source version is `0.2.0-alpha06` (`versionCode=8`)
- GitHub latest release is `v0.2.0-alpha06`
- F-Droid currently lists `0.2.0-alpha06 (8)` as the suggested version
- issue #8 reporter confirmed the microG flow works after enabling Harbor's alpha06 cross-profile control
- unresolved HyperOS issue #19 is intentionally not presented as verified compatibility data

Docs/site only; no application code or policy behavior changed.